### PR TITLE
[ADH-8124] Add S3 Gateway ozone objects cache

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4199,6 +4199,54 @@
       Ex: s3g/_HOST@REALM.COM</description>
   </property>
   <property>
+    <name>ozone.s3g.object.cache.enabled</name>
+    <value>false</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>Enable or disable the S3Gateway object cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.metrics.enabled</name>
+    <value>true</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>Enable or disable metrics for the S3Gateway object cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.volume.size</name>
+    <value>10</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>Maximum number of entries in the S3Gateway volume cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.volume.ttl.ms</name>
+    <value>3000</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>TTL in milliseconds for entries in the S3Gateway volume cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.bucket.size</name>
+    <value>100</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>Maximum number of entries in the S3Gateway bucket cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.bucket.ttl.ms</name>
+    <value>3000</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>TTL in milliseconds for entries in the S3Gateway bucket cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.key.size</name>
+    <value>1000</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>Maximum number of entries in the S3Gateway key cache.</description>
+  </property>
+  <property>
+    <name>ozone.s3g.object.cache.key.ttl.ms</name>
+    <value>3000</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>TTL in milliseconds for entries in the S3Gateway key cache.</description>
+  </property>
+  <property>
     <name>hdds.container.checksum.verification.enabled</name>
     <value>true</value>
     <tag>OZONE, DATANODE</tag>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -55,7 +55,8 @@ public final class OzoneClientFactory {
   /**
    * Private constructor, class is not meant to be initialized.
    */
-  private OzoneClientFactory() { }
+  private OzoneClientFactory() {
+  }
 
   public static UncheckedAutoCloseable track(AutoCloseable object) {
     final Class<?> clazz = object.getClass();
@@ -69,7 +70,6 @@ public final class OzoneClientFactory {
    * Constructs and return an OzoneClient with default configuration.
    *
    * @return OzoneClient
-   *
    * @throws IOException
    */
   public static OzoneClient getRpcClient() throws IOException {
@@ -80,21 +80,14 @@ public final class OzoneClientFactory {
   /**
    * Returns an OzoneClient which will use RPC protocol.
    *
-   * @param omHost
-   *        hostname of OzoneManager to connect.
-   *
-   * @param omRpcPort
-   *        RPC port of OzoneManager.
-   *
-   * @param config
-   *        Configuration to be used for OzoneClient creation
-   *
+   * @param omHost    hostname of OzoneManager to connect.
+   * @param omRpcPort RPC port of OzoneManager.
+   * @param config    Configuration to be used for OzoneClient creation
    * @return OzoneClient
-   *
    * @throws IOException
    */
   public static OzoneClient getRpcClient(String omHost, Integer omRpcPort,
-      MutableConfigurationSource config)
+                                         MutableConfigurationSource config)
       throws IOException {
     Objects.requireNonNull(omHost, "omHost == null");
     Objects.requireNonNull(omRpcPort, "omRpcPort == null");
@@ -107,22 +100,25 @@ public final class OzoneClientFactory {
   /**
    * Returns an OzoneClient which will use RPC protocol.
    *
-   * @param omServiceId
-   *        Service ID of OzoneManager HA cluster.
-   *
-   * @param config
-   *        Configuration to be used for OzoneClient creation
-   *
+   * @param omServiceId Service ID of OzoneManager HA cluster.
+   * @param config      Configuration to be used for OzoneClient creation
    * @return OzoneClient
-   *
    * @throws IOException
    */
   public static OzoneClient getRpcClient(String omServiceId,
-      ConfigurationSource config) throws IOException {
+                                         ConfigurationSource config) throws IOException {
+    return getRpcClient(omServiceId, config, OzoneClientFactory::getClientProtocol);
+  }
+
+  /**
+   * Returns an OzoneClient which will use RPC protocol.
+   */
+  public static OzoneClient getRpcClient(String omServiceId, ConfigurationSource config,
+                                         ClientProtocolProvider clientProtocolProvider) throws IOException {
     Objects.requireNonNull(omServiceId, "omServiceId == null");
     Objects.requireNonNull(config, "config == null");
     if (OmUtils.isOmHAServiceId(config, omServiceId)) {
-      return getRpcClient(getClientProtocol(config, omServiceId), config);
+      return getRpcClient(clientProtocolProvider.provide(config, omServiceId), config);
     } else {
       throw new IOException("Service ID specified " +
           "does not match with " + OZONE_OM_SERVICE_IDS_KEY + " defined in " +
@@ -134,14 +130,20 @@ public final class OzoneClientFactory {
   /**
    * Returns an OzoneClient which will use RPC protocol.
    *
-   * @param config
-   *        used for OzoneClient creation
-   *
+   * @param config used for OzoneClient creation
    * @return OzoneClient
-   *
    * @throws IOException
    */
   public static OzoneClient getRpcClient(ConfigurationSource config)
+      throws IOException {
+    return getRpcClient(config, OzoneClientFactory::getClientProtocol);
+  }
+
+  /**
+   * Returns an OzoneClient which will use RPC protocol.
+   */
+  public static OzoneClient getRpcClient(ConfigurationSource config,
+                                         ClientProtocolProvider clientProtocolProvider)
       throws IOException {
     Objects.requireNonNull(config, "config == null");
 
@@ -156,35 +158,33 @@ public final class OzoneClientFactory {
           " defined in the configuration. Use the method getRpcClient which " +
           "takes serviceID and configuration as param");
     } else if (serviceIds.length == 1) {
-      return getRpcClient(getClientProtocol(config, serviceIds[0]), config);
+      return getRpcClient(clientProtocolProvider.provide(config, serviceIds[0]), config);
     } else {
-      return getRpcClient(getClientProtocol(config), config);
+      return getRpcClient(clientProtocolProvider.provide(config, null), config);
     }
   }
 
   /**
    * Creates OzoneClient with the given ClientProtocol and Configuration.
    *
-   * @param clientProtocol
-   *        Protocol to be used by the OzoneClient
-   *
-   * @param config
-   *        Configuration to be used for OzoneClient creation
+   * @param clientProtocol Protocol to be used by the OzoneClient
+   * @param config         Configuration to be used for OzoneClient creation
    */
   private static OzoneClient getRpcClient(ClientProtocol clientProtocol,
-                                       ConfigurationSource config) {
+                                          ConfigurationSource config) {
     return new OzoneClient(config, clientProtocol);
   }
 
   /**
    * Create OzoneClient for token renew/cancel operations.
-   * @param conf Configuration to be used for OzoneCient creation
+   *
+   * @param conf  Configuration to be used for OzoneCient creation
    * @param token ozone token is involved
    * @return OzoneClient
    * @throws IOException
    */
   public static OzoneClient getOzoneClient(Configuration conf,
-      Token<OzoneTokenIdentifier> token) throws IOException {
+                                           Token<OzoneTokenIdentifier> token) throws IOException {
     Objects.requireNonNull(token, "Null token is not allowed");
     OzoneTokenIdentifier tokenId = new OzoneTokenIdentifier();
     ByteArrayInputStream buf = new ByteArrayInputStream(
@@ -228,12 +228,8 @@ public final class OzoneClientFactory {
   /**
    * Returns an instance of Protocol class.
    *
-   *
-   * @param config
-   *        Configuration used to initialize ClientProtocol.
-   *
+   * @param config Configuration used to initialize ClientProtocol.
    * @return ClientProtocol
-   *
    * @throws IOException
    */
   private static ClientProtocol getClientProtocol(ConfigurationSource config)
@@ -244,16 +240,12 @@ public final class OzoneClientFactory {
   /**
    * Returns an instance of Protocol class.
    *
-   *
-   * @param config
-   *        Configuration used to initialize ClientProtocol.
-   *
+   * @param config Configuration used to initialize ClientProtocol.
    * @return ClientProtocol
-   *
    * @throws IOException
    */
   private static ClientProtocol getClientProtocol(ConfigurationSource config,
-      String omServiceId) throws IOException {
+                                                  String omServiceId) throws IOException {
     try {
       return new RpcClient(config, omServiceId);
     } catch (Exception e) {
@@ -269,4 +261,10 @@ public final class OzoneClientFactory {
     }
   }
 
+  /**
+   * Provides a ClientProtocol instance.
+   */
+  public interface ClientProtocolProvider {
+    ClientProtocol provide(ConfigurationSource config, String omServiceId) throws IOException;
+  }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -508,7 +508,7 @@ public class RpcClient implements ClientProtocol {
     return resp;
   }
 
-  private void updateS3Principal(String userPrincipal) {
+  protected void updateS3Principal(String userPrincipal) {
     S3Auth s3Auth = this.getThreadLocalS3Auth();
     // Update user principal if needed to be used for KMS client
     if (s3Auth != null) {
@@ -1880,8 +1880,7 @@ public class RpcClient implements ClientProtocol {
     return getOzoneKeyDetails(keyInfo);
   }
 
-  @Nonnull
-  private OmKeyInfo getS3KeyInfo(
+  protected KeyInfoWithVolumeContext getS3KeyInfoWithS3Ctx(
       String bucketName, String keyName, boolean isHeadOp) throws IOException {
     verifyBucketName(bucketName);
     Objects.requireNonNull(keyName, "keyName == null");
@@ -1897,14 +1896,19 @@ public class RpcClient implements ClientProtocol {
         .setForceUpdateContainerCacheFromSCM(false)
         .setHeadOp(isHeadOp)
         .build();
+    return ozoneManagerClient.getKeyInfo(keyArgs, true);
+  }
+
+  @Nonnull
+  private OmKeyInfo getS3KeyInfo(
+      String bucketName, String keyName, boolean isHeadOp) throws IOException {
     KeyInfoWithVolumeContext keyInfoWithS3Context =
-        ozoneManagerClient.getKeyInfo(keyArgs, true);
+        getS3KeyInfoWithS3Ctx(bucketName, keyName, isHeadOp);
     keyInfoWithS3Context.getUserPrincipal().ifPresent(this::updateS3Principal);
     return keyInfoWithS3Context.getKeyInfo();
   }
 
-  @Nonnull
-  private OmKeyInfo getS3PartKeyInfo(
+  protected KeyInfoWithVolumeContext getS3PartKeyInfoWithS3Ctx(
       String bucketName, String keyName, int partNumber) throws IOException {
     verifyBucketName(bucketName);
     Objects.requireNonNull(keyName, "keyName == null");
@@ -1920,8 +1924,14 @@ public class RpcClient implements ClientProtocol {
         .setForceUpdateContainerCacheFromSCM(false)
         .setMultipartUploadPartNumber(partNumber)
         .build();
+    return ozoneManagerClient.getKeyInfo(keyArgs, true);
+  }
+
+  @Nonnull
+  private OmKeyInfo getS3PartKeyInfo(
+      String bucketName, String keyName, int partNumber) throws IOException {
     KeyInfoWithVolumeContext keyInfoWithS3Context =
-        ozoneManagerClient.getKeyInfo(keyArgs, true);
+        getS3PartKeyInfoWithS3Ctx(bucketName, keyName, partNumber);
     keyInfoWithS3Context.getUserPrincipal().ifPresent(this::updateS3Principal);
     return keyInfoWithS3Context.getKeyInfo();
   }

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -21,6 +21,7 @@ share/ozone/lib/bcutil-jdk18on.jar
 share/ozone/lib/bonecp.RELEASE.jar
 share/ozone/lib/caffeine.jar
 share/ozone/lib/cdi-api.SP1.jar
+share/ozone/lib/checker-qual.jar
 share/ozone/lib/commons-beanutils.jar
 share/ozone/lib/commons-cli.jar
 share/ozone/lib/commons-codec.jar

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
     </dependency>

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
@@ -19,27 +19,20 @@ package org.apache.hadoop.ozone.s3;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_ENABLED;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_ENABLED_DEFAULT;
 
 import java.io.IOException;
-import java.security.cert.CertificateException;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.OmUtils;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
-import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
+import org.apache.hadoop.ozone.s3.client.CachingS3OzoneClientBuilder;
+import org.apache.hadoop.ozone.s3.client.S3OzoneClientBuilder;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,86 +74,15 @@ public class OzoneClientCache {
   }
 
   public static OzoneClient createClient(OzoneConfiguration ozoneConfiguration) throws IOException {
-    String omServiceID = OmUtils.getOzoneManagerServiceId(ozoneConfiguration);
-    SecurityConfig secConfig = new SecurityConfig(ozoneConfiguration);
-    try {
-      if (secConfig.isGrpcTlsEnabled()) {
-        if (ozoneConfiguration
-            .get(OZONE_OM_TRANSPORT_CLASS,
-                OZONE_OM_TRANSPORT_CLASS_DEFAULT) !=
-            OZONE_OM_TRANSPORT_CLASS_DEFAULT) {
-          // Grpc transport selected
-          // need to get certificate for TLS through
-          // hadoop rpc first via ServiceInfo
-          setCertificate(secConfig, omServiceID, ozoneConfiguration);
-        }
-      }
-      if (omServiceID == null) {
-        return OzoneClientFactory.getRpcClient(ozoneConfiguration);
-      } else {
-        // As in HA case, we need to pass om service ID.
-        return OzoneClientFactory.getRpcClient(omServiceID,
-            ozoneConfiguration);
-      }
-    } catch (IOException e) {
-      LOG.warn("cannot create OzoneClient", e);
-      throw e;
-    }
-  }
+    boolean isCachingClientEnabled = ozoneConfiguration.getBoolean(
+        OZONE_S3G_OBJECT_CACHE_ENABLED,
+        OZONE_S3G_OBJECT_CACHE_ENABLED_DEFAULT);
 
-  private static void setCertificate(SecurityConfig secConfig, String omServiceID, OzoneConfiguration conf)
-      throws IOException {
+    S3OzoneClientBuilder clientBuilder = isCachingClientEnabled
+        ? new CachingS3OzoneClientBuilder()
+        : new S3OzoneClientBuilder();
 
-    // create local copy of config incase exception occurs
-    // with certificate OmRequest
-    OzoneConfiguration config = new OzoneConfiguration(conf);
-    OzoneClient certClient;
-
-    if (secConfig.isGrpcTlsEnabled()) {
-      // set OmTransport to hadoop rpc to securely,
-      // get certificates with service list request
-      config.set(OZONE_OM_TRANSPORT_CLASS,
-          OZONE_OM_TRANSPORT_CLASS_DEFAULT);
-      config.setBoolean(S3Auth.S3_AUTH_CHECK, false);
-
-      if (omServiceID == null) {
-        certClient = OzoneClientFactory.getRpcClient(config);
-      } else {
-        // As in HA case, we need to pass om service ID.
-        certClient = OzoneClientFactory.getRpcClient(omServiceID,
-            config);
-      }
-      try {
-        ServiceInfoEx serviceInfoEx = certClient
-            .getObjectStore()
-            .getClientProxy()
-            .getOzoneManagerClient()
-            .getServiceInfo();
-
-        if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
-          String caCertPem = null;
-          List<String> caCertPems = null;
-          caCertPem = serviceInfoEx.getCaCertificate();
-          caCertPems = serviceInfoEx.getCaCertPemList();
-          if (caCertPems == null || caCertPems.isEmpty()) {
-            if (caCertPem == null) {
-              LOG.error("S3g received empty caCertPems from serviceInfo");
-              throw new CertificateException("No caCerts found; caCertPem can" +
-                  " not be null when caCertPems is empty or null");
-            }
-            caCertPems = Collections.singletonList(caCertPem);
-          }
-          GrpcOmTransport.setCaCerts(OzoneSecurityUtil
-              .convertToX509(caCertPems));
-        }
-      } catch (CertificateException ce) {
-        throw new IOException(ce);
-      } finally {
-        if (certClient != null) {
-          certClient.close();
-        }
-      }
-    }
+    return clientBuilder.fromConfig(ozoneConfiguration);
   }
 
   @PreDestroy

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -72,6 +72,40 @@ public final class S3GatewayConfigKeys {
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT =
       "4MB";
 
+  public static final String OZONE_S3G_OBJECT_CACHE_ENABLED =
+      "ozone.s3g.object.cache.enabled";
+  public static final boolean OZONE_S3G_OBJECT_CACHE_ENABLED_DEFAULT =
+      false;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED =
+      "ozone.s3g.object.cache.metrics.enabled";
+  public static final boolean OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED_DEFAULT =
+      true;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE =
+      "ozone.s3g.object.cache.volume.size";
+  public static final int OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE_DEFAULT = 10;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS =
+      "ozone.s3g.object.cache.volume.ttl.ms";
+  public static final long OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS_DEFAULT = 3000L;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE =
+      "ozone.s3g.object.cache.bucket.size";
+  public static final int OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE_DEFAULT = 100;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS =
+      "ozone.s3g.object.cache.bucket.ttl.ms";
+  public static final long OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS_DEFAULT = 3000L;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE =
+      "ozone.s3g.object.cache.key.size";
+  public static final int OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE_DEFAULT = 1000;
+
+  public static final String OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS =
+      "ozone.s3g.object.cache.key.ttl.ms";
+  public static final long OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS_DEFAULT = 3000L;
+
   // S3G kerberos, principal config
   public static final String OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY =
       "ozone.s3g.kerberos.keytab.file";

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/CachingS3OzoneClientBuilder.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/CachingS3OzoneClientBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension of {@link S3OzoneClientBuilder} that produces an
+ * {@link OzoneClient} backed by a {@link CachingS3OzoneRpcClient}.
+ */
+public class CachingS3OzoneClientBuilder extends S3OzoneClientBuilder {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CachingS3OzoneClientBuilder.class);
+
+  @Override
+  protected OzoneClient getRpcClient(OzoneConfiguration ozoneConfiguration) throws IOException {
+    return OzoneClientFactory.getRpcClient(
+        ozoneConfiguration, CachingS3OzoneClientBuilder::getCachingRpcClient);
+  }
+
+  @Override
+  protected OzoneClient getRpcClient(String omServiceId, OzoneConfiguration ozoneConfiguration) throws IOException {
+    return OzoneClientFactory.getRpcClient(
+        omServiceId, ozoneConfiguration, CachingS3OzoneClientBuilder::getCachingRpcClient);
+  }
+
+  private static ClientProtocol getCachingRpcClient(ConfigurationSource config,
+                                                    String omServiceId) throws IOException {
+    try {
+      return new CachingS3OzoneRpcClient(config, omServiceId);
+    } catch (Exception e) {
+      final String message = "Couldn't create CachingS3OzoneRpcClient protocol";
+      LOG.error(message, e);
+      if (e instanceof RemoteException) {
+        throw ((RemoteException) e).unwrapRemoteException();
+      } else if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      } else {
+        throw new IOException(message, e);
+      }
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/CachingS3OzoneRpcClient.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/CachingS3OzoneRpcClient.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client;
+
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS_DEFAULT;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE_DEFAULT;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.om.helpers.ErrorInfo;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
+import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
+import org.apache.hadoop.ozone.s3.client.cache.BucketCacheCacheKey;
+import org.apache.hadoop.ozone.s3.client.cache.LocalOzoneObjectCache;
+import org.apache.hadoop.ozone.s3.client.cache.OzoneObjectCache;
+import org.apache.hadoop.ozone.s3.client.cache.S3KeyDetailsCacheCacheKey;
+import org.apache.hadoop.ozone.s3.client.cache.S3KeyInfoCacheCacheKey;
+import org.apache.hadoop.ozone.s3.client.cache.S3ObjectCacheKey;
+import org.apache.hadoop.ozone.s3.client.cache.S3ObjectCacheMetrics;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.ratis.util.function.CheckedFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link RpcClient} that caches S3 volume context, bucket, and key
+ * lookups in local per-user Caffeine caches to reduce repeated OM RPCs.
+ * Cache entries are evicted on write operations (delete, rename) or by TTL.
+ */
+public class CachingS3OzoneRpcClient extends RpcClient {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CachingS3OzoneRpcClient.class);
+
+  private final OzoneObjectCache<S3ObjectCacheKey, S3VolumeContext> volumeCache;
+  private final OzoneObjectCache<BucketCacheCacheKey, OzoneBucket> bucketCache;
+  private final OzoneObjectCache<S3KeyInfoCacheCacheKey, KeyInfoWithVolumeContext> headKeyInfoCache;
+  private final OzoneObjectCache<S3KeyDetailsCacheCacheKey, KeyInfoWithVolumeContext> keyInfoCache;
+
+  private final S3ObjectCacheMetrics cacheMetrics;
+
+  public CachingS3OzoneRpcClient(ConfigurationSource conf, String omServiceId) throws IOException {
+    super(conf, omServiceId);
+
+    this.volumeCache = new LocalOzoneObjectCache<>(
+        this::loadVolumeContext,
+        conf.getInt(OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE,
+            OZONE_S3G_OBJECT_CACHE_VOLUME_MAX_SIZE_DEFAULT),
+        Duration.ofMillis(conf.getLong(OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS,
+            OZONE_S3G_OBJECT_CACHE_VOLUME_ENTRY_TTL_SECONDS_DEFAULT))
+    );
+
+    this.bucketCache = new LocalOzoneObjectCache<>(
+        this::loadBucket,
+        conf.getInt(OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE,
+            OZONE_S3G_OBJECT_CACHE_BUCKET_MAX_SIZE_DEFAULT),
+        Duration.ofMillis(conf.getLong(OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS,
+            OZONE_S3G_OBJECT_CACHE_BUCKET_ENTRY_TTL_SECONDS_DEFAULT))
+    );
+
+    int keyCacheMaxSize = conf.getInt(OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE,
+        OZONE_S3G_OBJECT_CACHE_KEY_MAX_SIZE_DEFAULT);
+    Duration keyCacheTtl = Duration.ofMillis(conf.getLong(OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS,
+        OZONE_S3G_OBJECT_CACHE_KEY_ENTRY_TTL_SECONDS_DEFAULT));
+
+    this.headKeyInfoCache = new LocalOzoneObjectCache<>(
+        this::loadHeadKeyInfoWithCtx,
+        keyCacheMaxSize,
+        keyCacheTtl
+    );
+
+    this.keyInfoCache = new LocalOzoneObjectCache<>(
+        this::loadKeyInfoWithCtx,
+        keyCacheMaxSize,
+        keyCacheTtl
+    );
+
+    boolean cacheMetricsEnabled = conf.getBoolean(
+        OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED,
+        OZONE_S3G_OBJECT_CACHE_METRICS_ENABLED_DEFAULT);
+
+    this.cacheMetrics = cacheMetricsEnabled ? initCacheMetrics() : null;
+  }
+
+  @Override
+  public S3VolumeContext getS3VolumeContext() throws IOException {
+    S3VolumeContext s3VolumeContext = volumeCache.get(new S3ObjectCacheKey(getThreadLocalS3Auth()));
+    updateS3Principal(s3VolumeContext.getUserPrincipal());
+    return s3VolumeContext;
+  }
+
+  @Override
+  public OzoneBucket getBucketDetails(String volumeName, String bucketName) throws IOException {
+    return bucketCache.get(new BucketCacheCacheKey(volumeName, bucketName, getThreadLocalS3Auth()));
+  }
+
+  // no need to update S3Principal, because it's done in the parent client
+  @Override
+  protected KeyInfoWithVolumeContext getS3KeyInfoWithS3Ctx(
+      String bucketName, String keyName, boolean isHeadOp) throws IOException {
+    return isHeadOp
+        ? headKeyInfoCache.get(new S3KeyInfoCacheCacheKey(bucketName, keyName, getThreadLocalS3Auth()))
+        : keyInfoCache.get(new S3KeyDetailsCacheCacheKey(bucketName, keyName, null, getThreadLocalS3Auth()));
+  }
+
+  // no need to update S3Principal, because it's done in the parent client
+  @Override
+  protected KeyInfoWithVolumeContext getS3PartKeyInfoWithS3Ctx(
+      String bucketName, String keyName, int partNumber) throws IOException {
+    return keyInfoCache.get(new S3KeyDetailsCacheCacheKey(bucketName, keyName, partNumber, getThreadLocalS3Auth()));
+  }
+
+  @Override
+  public void deleteBucket(String volumeName, String bucketName) throws IOException {
+    try {
+      super.deleteBucket(volumeName, bucketName);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void deleteKey(String volumeName, String bucketName, String keyName, boolean recursive) throws IOException {
+    try {
+      super.deleteKey(volumeName, bucketName, keyName, recursive);
+    } finally {
+      evictKeyCacheEntry(bucketName, keyName);
+    }
+  }
+
+  @Override
+  public void deleteKeys(String volumeName, String bucketName, List<String> keyNameList) throws IOException {
+    try {
+      super.deleteKeys(volumeName, bucketName, keyNameList);
+    } finally {
+      keyNameList.forEach(keyName -> evictKeyCacheEntry(bucketName, keyName));
+    }
+  }
+
+  @Override
+  public Map<String, ErrorInfo> deleteKeys(String volumeName, String bucketName, List<String> keyNameList,
+                                           boolean quiet) throws IOException {
+    try {
+      return super.deleteKeys(volumeName, bucketName, keyNameList, quiet);
+    } finally {
+      keyNameList.forEach(keyName -> evictKeyCacheEntry(bucketName, keyName));
+    }
+  }
+
+  @Override
+  public void renameKey(String volumeName, String bucketName, String fromKeyName, String toKeyName)
+      throws IOException {
+    try {
+      super.renameKey(volumeName, bucketName, fromKeyName, toKeyName);
+    } finally {
+      evictKeyCacheEntry(bucketName, fromKeyName);
+      evictKeyCacheEntry(bucketName, toKeyName);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public void renameKeys(String volumeName, String bucketName, Map<String, String> keyMap) throws IOException {
+    try {
+      super.renameKeys(volumeName, bucketName, keyMap);
+    } finally {
+      keyMap.forEach((fromKey, toKey) -> {
+        evictKeyCacheEntry(bucketName, fromKey);
+        evictKeyCacheEntry(bucketName, toKey);
+      });
+    }
+  }
+
+  @Override
+  public void createBucket(String volumeName, String bucketName) throws IOException {
+    try {
+      super.createBucket(volumeName, bucketName);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void createBucket(String volumeName, String bucketName, BucketArgs bucketArgs) throws IOException {
+    try {
+      super.createBucket(volumeName, bucketName, bucketArgs);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public boolean setBucketOwner(String volumeName, String bucketName, String owner) throws IOException {
+    try {
+      return super.setBucketOwner(volumeName, bucketName, owner);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void setBucketVersioning(String volumeName, String bucketName, Boolean versioning) throws IOException {
+    try {
+      super.setBucketVersioning(volumeName, bucketName, versioning);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void setBucketStorageType(String volumeName, String bucketName, StorageType storageType) throws IOException {
+    try {
+      super.setBucketStorageType(volumeName, bucketName, storageType);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void setBucketQuota(String volumeName, String bucketName, long quotaInNamespace, long quotaInBytes)
+      throws IOException {
+    try {
+      super.setBucketQuota(volumeName, bucketName, quotaInNamespace, quotaInBytes);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public void setReplicationConfig(String volumeName, String bucketName, ReplicationConfig replicationConfig)
+      throws IOException {
+    try {
+      super.setReplicationConfig(volumeName, bucketName, replicationConfig);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public void setEncryptionKey(String volumeName, String bucketName, String bekName) throws IOException {
+    try {
+      super.setEncryptionKey(volumeName, bucketName, bekName);
+    } finally {
+      evictBucketCacheEntry(volumeName, bucketName);
+    }
+  }
+
+  @Override
+  public boolean setAcl(OzoneObj obj, List<OzoneAcl> acls) throws IOException {
+    try {
+      return super.setAcl(obj, acls);
+    } finally {
+      if (obj.getResourceType() == OzoneObj.ResourceType.BUCKET) {
+        evictBucketCacheEntry(obj.getVolumeName(), obj.getBucketName());
+      } else if (obj.getResourceType() == OzoneObj.ResourceType.KEY) {
+        evictKeyCacheEntry(obj.getBucketName(), obj.getKeyName());
+      }
+    }
+  }
+
+  @Override
+  public OzoneOutputStream createKey(String volumeName, String bucketName, String keyName, long size,
+                                     ReplicationConfig replicationConfig, Map<String, String> metadata,
+                                     Map<String, String> tags)
+      throws IOException {
+    evictKeyCacheEntry(bucketName, keyName);
+    return withEvictOnClose(
+        super.createKey(volumeName, bucketName, keyName, size, replicationConfig, metadata, tags),
+        bucketName, keyName);
+  }
+
+  @Override
+  public OzoneOutputStream rewriteKey(String volumeName, String bucketName, String keyName,
+                                      long size, long existingKeyGeneration, ReplicationConfig replicationConfig,
+                                      Map<String, String> metadata) throws IOException {
+    evictKeyCacheEntry(bucketName, keyName);
+    return withEvictOnClose(
+        super.rewriteKey(volumeName, bucketName, keyName, size, existingKeyGeneration, replicationConfig, metadata),
+        bucketName, keyName);
+  }
+
+  @Override
+  public OzoneOutputStream createKeyIfNotExists(String volumeName, String bucketName, String keyName,
+                                                long size, ReplicationConfig replicationConfig,
+                                                Map<String, String> metadata, Map<String, String> tags)
+      throws IOException {
+    evictKeyCacheEntry(bucketName, keyName);
+    return withEvictOnClose(
+        super.createKeyIfNotExists(volumeName, bucketName, keyName, size, replicationConfig, metadata, tags),
+        bucketName, keyName);
+  }
+
+  @SuppressWarnings("checkstyle:parameternumber")
+  @Override
+  public OzoneOutputStream rewriteKeyIfMatch(String volumeName, String bucketName, String keyName,
+                                             long size, String expectedETag, ReplicationConfig replicationConfig,
+                                             Map<String, String> metadata, Map<String, String> tags)
+      throws IOException {
+    evictKeyCacheEntry(bucketName, keyName);
+    return withEvictOnClose(
+        super.rewriteKeyIfMatch(volumeName, bucketName, keyName, size, expectedETag, replicationConfig, metadata, tags),
+        bucketName, keyName);
+  }
+
+  @Override
+  public OmMultipartUploadCompleteInfo completeMultipartUpload(
+      String volumeName, String bucketName, String keyName, String uploadID,
+      Map<Integer, String> partsMap) throws IOException {
+    try {
+      return super.completeMultipartUpload(volumeName, bucketName, keyName, uploadID, partsMap);
+    } finally {
+      evictKeyCacheEntry(bucketName, keyName);
+    }
+  }
+
+  @Override
+  public void putObjectTagging(String volumeName, String bucketName,
+                               String keyName, Map<String, String> tags) throws IOException {
+    try {
+      super.putObjectTagging(volumeName, bucketName, keyName, tags);
+    } finally {
+      evictKeyCacheEntry(bucketName, keyName);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      if (cacheMetrics != null) {
+        cacheMetrics.close();
+      }
+    }
+  }
+
+  private OzoneOutputStream withEvictOnClose(OzoneOutputStream stream, String bucketName, String keyName) {
+    return new EvictingOzoneOutputStream(stream, () -> evictKeyCacheEntry(bucketName, keyName));
+  }
+
+  private void evictBucketCacheEntry(String volumeName, String bucketName) {
+    try {
+      bucketCache.evict(new BucketCacheCacheKey(volumeName, bucketName, getThreadLocalS3Auth()));
+    } catch (Exception e) {
+      LOG.warn("Failed to evict bucket cache entry for volume: {}, bucket: {}", volumeName, bucketName, e);
+    }
+  }
+
+  private void evictKeyCacheEntry(String bucketName, String keyName) {
+    try {
+      headKeyInfoCache.evict(new S3KeyInfoCacheCacheKey(bucketName, keyName, getThreadLocalS3Auth()));
+      // we don't know the existing keys for multipart loads, so let them be evicted by ttl
+      keyInfoCache.evict(new S3KeyDetailsCacheCacheKey(bucketName, keyName, null, getThreadLocalS3Auth()));
+    } catch (Exception e) {
+      LOG.warn("Failed to evict key cache entry for bucket: {}, key: {}", bucketName, keyName, e);
+    }
+  }
+
+  private S3VolumeContext loadVolumeContext(S3ObjectCacheKey cacheKey) throws IOException {
+    return withS3Auth(cacheKey, key -> super.getS3VolumeContext());
+  }
+
+  private OzoneBucket loadBucket(BucketCacheCacheKey cacheKey) throws IOException {
+    return withS3Auth(cacheKey,
+        key -> super.getBucketDetails(key.getVolume(), key.getBucket()));
+  }
+
+  private KeyInfoWithVolumeContext loadHeadKeyInfoWithCtx(S3KeyInfoCacheCacheKey cacheKey) throws IOException {
+    return withS3Auth(cacheKey, key ->
+        super.getS3KeyInfoWithS3Ctx(cacheKey.getBucket(), cacheKey.getKey(), true));
+  }
+
+  private KeyInfoWithVolumeContext loadKeyInfoWithCtx(S3KeyDetailsCacheCacheKey cacheKey) throws IOException {
+    return withS3Auth(cacheKey,
+        key -> key.getPartNumber() == null
+            ? super.getS3KeyInfoWithS3Ctx(key.getBucket(), key.getKey(), false)
+            : super.getS3PartKeyInfoWithS3Ctx(key.getBucket(), key.getKey(), key.getPartNumber()));
+  }
+
+  // set S3 auth context for the cache loader thread
+  private <K extends S3ObjectCacheKey, V> V withS3Auth(K key, CheckedFunction<K, V, IOException> action)
+      throws IOException {
+    try {
+      setThreadLocalS3Auth(key.getS3Auth());
+      return action.apply(key);
+    } finally {
+      clearThreadLocalS3Auth();
+    }
+  }
+
+  private S3ObjectCacheMetrics initCacheMetrics() {
+    return S3ObjectCacheMetrics.register(
+        ImmutableMap.of(
+            "s3VolumeCache", volumeCache,
+            "s3BucketCache", bucketCache,
+            "s3HeadKeyCache", headKeyInfoCache,
+            "s3KeyInfoCache", keyInfoCache
+        )
+    );
+  }
+
+  private static final class EvictingOzoneOutputStream extends OzoneOutputStream {
+    private final OzoneOutputStream delegate;
+    private final Runnable onClose;
+
+    EvictingOzoneOutputStream(OzoneOutputStream delegate, Runnable onClose) {
+      super(delegate.getOutputStream(), null);
+      this.delegate = delegate;
+      this.onClose = onClose;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      try {
+        delegate.close();
+      } finally {
+        onClose.run();
+      }
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/S3OzoneClientBuilder.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/S3OzoneClientBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS_DEFAULT;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds an {@link OzoneClient} for use in the S3 Gateway, handling
+ * TLS certificate retrieval when gRPC transport with TLS is configured.
+ */
+public class S3OzoneClientBuilder {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(S3OzoneClientBuilder.class);
+
+  public OzoneClient fromConfig(OzoneConfiguration ozoneConfiguration) throws IOException {
+    String omServiceID = OmUtils.getOzoneManagerServiceId(ozoneConfiguration);
+    SecurityConfig secConfig = new SecurityConfig(ozoneConfiguration);
+    try {
+      if (secConfig.isGrpcTlsEnabled()) {
+        if (!Objects.equals(ozoneConfiguration
+            .get(OZONE_OM_TRANSPORT_CLASS,
+                OZONE_OM_TRANSPORT_CLASS_DEFAULT), OZONE_OM_TRANSPORT_CLASS_DEFAULT)) {
+          // Grpc transport selected
+          // need to get certificate for TLS through
+          // hadoop rpc first via ServiceInfo
+          setCertificate(secConfig, omServiceID, ozoneConfiguration);
+        }
+      }
+      if (omServiceID == null) {
+        return getRpcClient(ozoneConfiguration);
+      } else {
+        // As in HA case, we need to pass om service ID.
+        return getRpcClient(omServiceID, ozoneConfiguration);
+      }
+    } catch (IOException e) {
+      LOG.warn("cannot create OzoneClient", e);
+      throw e;
+    }
+  }
+
+  private static void setCertificate(SecurityConfig secConfig, String omServiceID, OzoneConfiguration conf)
+      throws IOException {
+
+    // create local copy of config incase exception occurs
+    // with certificate OmRequest
+    OzoneConfiguration config = new OzoneConfiguration(conf);
+    OzoneClient certClient;
+
+    if (secConfig.isGrpcTlsEnabled()) {
+      // set OmTransport to hadoop rpc to securely,
+      // get certificates with service list request
+      config.set(OZONE_OM_TRANSPORT_CLASS,
+          OZONE_OM_TRANSPORT_CLASS_DEFAULT);
+      config.setBoolean(S3Auth.S3_AUTH_CHECK, false);
+
+      if (omServiceID == null) {
+        certClient = OzoneClientFactory.getRpcClient(config);
+      } else {
+        // As in HA case, we need to pass om service ID.
+        certClient = OzoneClientFactory.getRpcClient(omServiceID,
+            config);
+      }
+      try {
+        ServiceInfoEx serviceInfoEx = certClient
+            .getObjectStore()
+            .getClientProxy()
+            .getOzoneManagerClient()
+            .getServiceInfo();
+
+        if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+          String caCertPem = null;
+          List<String> caCertPems = null;
+          caCertPem = serviceInfoEx.getCaCertificate();
+          caCertPems = serviceInfoEx.getCaCertPemList();
+          if (caCertPems == null || caCertPems.isEmpty()) {
+            if (caCertPem == null) {
+              LOG.error("S3g received empty caCertPems from serviceInfo");
+              throw new CertificateException("No caCerts found; caCertPem can" +
+                  " not be null when caCertPems is empty or null");
+            }
+            caCertPems = Collections.singletonList(caCertPem);
+          }
+          GrpcOmTransport.setCaCerts(OzoneSecurityUtil
+              .convertToX509(caCertPems));
+        }
+      } catch (CertificateException ce) {
+        throw new IOException(ce);
+      } finally {
+        if (certClient != null) {
+          certClient.close();
+        }
+      }
+    }
+  }
+
+  protected OzoneClient getRpcClient(OzoneConfiguration ozoneConfiguration) throws IOException {
+    return OzoneClientFactory.getRpcClient(ozoneConfiguration);
+  }
+
+  protected OzoneClient getRpcClient(String omServiceId, OzoneConfiguration ozoneConfiguration) throws IOException {
+    return OzoneClientFactory.getRpcClient(omServiceId, ozoneConfiguration);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/BucketCacheCacheKey.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/BucketCacheCacheKey.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+
+/**
+ * Cache key identifying an Ozone bucket by volume name, bucket name,
+ * and the S3 authentication credentials of the requesting user.
+ */
+public class BucketCacheCacheKey extends S3ObjectCacheKey {
+  private final String volume;
+  private final String bucket;
+
+  public BucketCacheCacheKey(String volume, String bucket, S3Auth s3Auth) {
+    super(s3Auth);
+    this.volume = volume;
+    this.bucket = bucket;
+  }
+
+  public String getVolume() {
+    return volume;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (!(o instanceof BucketCacheCacheKey)) {
+      return false;
+    }
+    BucketCacheCacheKey that = (BucketCacheCacheKey) o;
+    return Objects.equals(volume, that.volume)
+        && Objects.equals(bucket, that.bucket);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), volume, bucket);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/LocalOzoneObjectCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/LocalOzoneObjectCache.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.ratis.util.function.CheckedFunction;
+
+/**
+ * In-process implementation of {@link OzoneObjectCache} backed by a
+ * Caffeine async loading cache with configurable maximum size and TTL.
+ */
+public class LocalOzoneObjectCache<K, V> implements OzoneObjectCache<K, V> {
+
+  private final AsyncLoadingCache<K, V> cache;
+
+  public LocalOzoneObjectCache(CheckedFunction<K, V, Exception> valueLoader, int maxSize, Duration entryTll) {
+    this.cache = Caffeine.newBuilder()
+        .maximumSize(maxSize)
+        .expireAfterWrite(entryTll)
+        .recordStats()
+        .buildAsync(valueLoader::apply);
+  }
+
+  @Override
+  public V get(K key) throws IOException {
+    try {
+      return cache.get(key).join();
+    } catch (CompletionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new IOException(cause);
+    }
+  }
+
+  @Override
+  public void evict(K key) {
+    cache.synchronous().invalidate(key);
+  }
+
+  @Override
+  public void registerMetrics(MetricsRecordBuilder metricsRecordBuilder) {
+    CacheStats stats = cache.synchronous().stats();
+    metricsRecordBuilder
+        .addGauge(Interns.info("hitCount", "Cache hit count"), stats.hitCount())
+        .addGauge(Interns.info("hitRate", "Cache hit rate"), stats.hitRate())
+        .addGauge(Interns.info("missCount", "Cache miss count"), stats.missCount())
+        .addGauge(Interns.info("loadSuccessCount", "Successful cache loads"), stats.loadSuccessCount())
+        .addGauge(Interns.info("loadFailureCount", "Failed cache loads"), stats.loadFailureCount())
+        .addGauge(Interns.info("loadFailureRate", "Failed cache loads rate"), stats.loadFailureRate())
+        .addGauge(Interns.info("evictionCount", "Cache eviction count"), stats.evictionCount())
+        .addGauge(Interns.info("averageLoadPenalty", "Average load penalty (ns)"), stats.averageLoadPenalty());
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/OzoneObjectCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/OzoneObjectCache.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.io.IOException;
+import java.time.Duration;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.ratis.util.function.CheckedFunction;
+
+/**
+ * Generic cache interface for Ozone objects, supporting retrieval, eviction,
+ * and metrics registration.
+ */
+public interface OzoneObjectCache<K, V> {
+  V get(K key) throws IOException;
+
+  void evict(K key);
+
+  void registerMetrics(MetricsRecordBuilder metricsRecordBuilder);
+
+  static <K, V> OzoneObjectCache<K, V> local(CheckedFunction<K, V, Exception> valueProvider, int maxSize,
+                                             Duration entryTll) {
+    return new LocalOzoneObjectCache<>(valueProvider, maxSize, entryTll);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3KeyDetailsCacheCacheKey.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3KeyDetailsCacheCacheKey.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+
+/**
+ * Cache key for detailed S3 key lookups, extending {@link S3KeyInfoCacheCacheKey}
+ * with an optional multipart part number to distinguish part-level requests.
+ */
+public class S3KeyDetailsCacheCacheKey extends S3KeyInfoCacheCacheKey {
+  private final Integer partNumber;
+
+  public S3KeyDetailsCacheCacheKey(String bucket, String key, Integer part, S3Auth s3Auth) {
+    super(bucket, key, s3Auth);
+    this.partNumber = part;
+  }
+
+  public Integer getPartNumber() {
+    return partNumber;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (!(o instanceof S3KeyDetailsCacheCacheKey)) {
+      return false;
+    }
+    S3KeyDetailsCacheCacheKey that = (S3KeyDetailsCacheCacheKey) o;
+    return Objects.equals(partNumber, that.partNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), partNumber);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3KeyInfoCacheCacheKey.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3KeyInfoCacheCacheKey.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+
+/**
+ * Cache key identifying an S3 object by bucket name, key name,
+ * and the S3 authentication credentials of the requesting user.
+ */
+public class S3KeyInfoCacheCacheKey extends S3ObjectCacheKey {
+  private final String bucket;
+  private final String key;
+
+  public S3KeyInfoCacheCacheKey(String bucket, String key, S3Auth s3Auth) {
+    super(s3Auth);
+    this.bucket = bucket;
+    this.key = key;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    S3KeyInfoCacheCacheKey that = (S3KeyInfoCacheCacheKey) o;
+    return Objects.equals(bucket, that.bucket) && Objects.equals(key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), bucket, key);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3ObjectCacheKey.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3ObjectCacheKey.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
+
+/**
+ * Base cache key that scopes cache entries to the S3 access ID of the
+ * requesting user, ensuring per-user cache isolation.
+ */
+public class S3ObjectCacheKey {
+  private final S3Auth s3Auth;
+
+  public S3ObjectCacheKey(S3Auth s3Auth) {
+    this.s3Auth = s3Auth;
+  }
+
+  public S3Auth getS3Auth() {
+    return s3Auth;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof S3ObjectCacheKey)) {
+      return false;
+    }
+    S3ObjectCacheKey that = (S3ObjectCacheKey) o;
+    // deliberately use only the immutable part of the S3Auth
+    return Objects.equals(s3Auth.getAccessID(), that.s3Auth.getAccessID());
+  }
+
+  @Override
+  public int hashCode() {
+    // deliberately use only the immutable part of the S3Auth
+    return Objects.hash(s3Auth.getAccessID());
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3ObjectCacheMetrics.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/S3ObjectCacheMetrics.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.client.cache;
+
+import java.io.Closeable;
+import java.util.Map;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
+
+/**
+ * Hadoop Metrics2 source that collects and publishes statistics for all
+ * registered S3 object caches (volume, bucket, and key caches).
+ */
+public class S3ObjectCacheMetrics implements MetricsSource, Closeable {
+  private static final String SOURCE_NAME = S3ObjectCacheMetrics.class.getSimpleName();
+
+  private final Map<String, OzoneObjectCache<?, ?>> caches;
+
+  public S3ObjectCacheMetrics(Map<String, OzoneObjectCache<?, ?>> caches) {
+    this.caches = caches;
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    caches.forEach((name, cache) -> {
+      MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME)
+          .tag(Interns.info("cacheName", "Cache name"), name);
+      cache.registerMetrics(recordBuilder);
+    });
+  }
+
+  @Override
+  public void close() {
+    DefaultMetricsSystem.instance().unregisterSource(SOURCE_NAME);
+  }
+
+  public static S3ObjectCacheMetrics register(Map<String, OzoneObjectCache<?, ?>> caches) {
+    S3ObjectCacheMetrics metrics = new S3ObjectCacheMetrics(caches);
+    DefaultMetricsSystem.instance().register(SOURCE_NAME, "S3 Object Cache Metrics", metrics);
+    return metrics;
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/package-info.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/cache/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cache infrastructure for the S3 Gateway Ozone client, providing
+ * per-user local caches for volume context, bucket, and key metadata
+ * to reduce repeated calls to the Ozone Manager.
+ */
+package org.apache.hadoop.ozone.s3.client.cache;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/package-info.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/client/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * S3 Gateway specific extensions to the Ozone client, including builders
+ * for creating plain and caching {@link org.apache.hadoop.ozone.client.OzoneClient}
+ * instances tailored for S3 Gateway use.
+ */
+package org.apache.hadoop.ozone.s3.client;

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <caffeine.version>2.9.3</caffeine.version>
     <cdi-api.version>2.0.SP1</cdi-api.version>
     <checkstyle.version>9.3</checkstyle.version>
     <classpath.skip>true</classpath.skip>
@@ -398,6 +399,11 @@
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>${woodstox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
Added caching OM client for S3 gateway component. Currently, it caches metadata for S3 volume, buckets, keys (both regular and extended versions) in local per-user Caffeine caches. Cache entries are evicted on corresponding write operations (delete, rename) or by TTL.

Related options:
 | Key | Description | Default Value |
|-----|-------------|---------------|
| `ozone.s3g.object.cache.enabled` | Enable or disable the S3Gateway object cache. | `false` |
| `ozone.s3g.object.cache.metrics.enabled` | Enable or disable metrics for the S3Gateway object cache. | `true` |
| `ozone.s3g.object.cache.volume.size` | Maximum number of entries in the S3Gateway volume cache. | `10` |
| `ozone.s3g.object.cache.volume.ttl.ms` | TTL in milliseconds for entries in the S3Gateway volume cache. | `3000` |
| `ozone.s3g.object.cache.bucket.size` | Maximum number of entries in the S3Gateway bucket cache. | `100` |
| `ozone.s3g.object.cache.bucket.ttl.ms` | TTL in milliseconds for entries in the S3Gateway bucket cache. | `3000` |
| `ozone.s3g.object.cache.key.size` | Maximum number of entries in the S3Gateway key cache. | `1000` |
| `ozone.s3g.object.cache.key.ttl.ms` | TTL in milliseconds for entries in the S3Gateway key cache. | `3000` |

Also a `Hadoop Metrics2` source is added to collect and publish the following statistics for all S3 object caches (`s3VolumeCache`, `s3BucketCache`, `s3HeadKeyCache`, `s3KeyInfoCache`):

| Name | Description |
|------|-------------|
| `hitCount` | Cache hit count |
| `hitRate` | Cache hit rate |
| `missCount` | Cache miss count |
| `loadSuccessCount` | Successful cache loads |
| `loadFailureCount` | Failed cache loads |
| `loadFailureRate` | Failed cache loads rate |
| `evictionCount` | Cache eviction count |
| `averageLoadPenalty` | Average load penalty (ns) |

Example of metrics if Prometheus MetricsSink is used:

```
# TYPE s3_object_cache_metrics_miss_count gauge
s3_object_cache_metrics_miss_count{cachename="s3BucketCache",hostname="0dfbab4b336f"} 27
s3_object_cache_metrics_miss_count{cachename="s3HeadKeyCache",hostname="0dfbab4b336f"} 10
s3_object_cache_metrics_miss_count{cachename="s3KeyInfoCache",hostname="0dfbab4b336f"} 5
s3_object_cache_metrics_miss_count{cachename="s3VolumeCache",hostname="0dfbab4b336f"} 30
```