### PR TITLE
ADH-8304: Do not apply WebUI auth filter to S3 API object paths

### DIFF
--- a/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
+++ b/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
@@ -68,6 +68,10 @@ ozone.s3g.http.auth.type | kerberos
 ozone.s3g.http.auth.kerberos.principal | HTTP/_HOST@REALM
 ozone.s3g.http.auth.kerberos.keytab| /path/to/HTTP.keytab
 
+For S3 Gateway, SPNEGO authentication protects the WebAdmin and web-console
+HTTP pages. S3-compatible object API requests continue to use S3 credentials
+and SigV4 authentication, and are not authenticated by the WebUI SPNEGO filter.
+
 ### Enable SPNEGO authentication for RECON HTTP
 Property| Value
 -----------------------------------|-----------------------------------------

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -134,6 +134,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
           HddsConfigKeys.HDDS_XFRAME_OPTION_VALUE_DEFAULT);
 
       builder.configureXFrame(xFrameEnabled).setXFrameOption(xFrameOptionValue);
+      builder.setWebAppFilterPathSpecs(getWebAppFilterPathSpecs());
 
       boolean addDefaultApps = shouldAddDefaultApps();
       if (!addDefaultApps) {
@@ -494,6 +495,10 @@ public abstract class BaseHttpServer implements AutoCloseable {
   /** Override to disable the default servlets. */
   protected boolean shouldAddDefaultApps() {
     return true;
+  }
+
+  protected String[] getWebAppFilterPathSpecs() {
+    return null;
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -349,10 +349,10 @@ public final class HttpServer2 implements FilterContainer {
       return this;
     }
 
-    public Builder setWebAppFilterPathSpecs(String[] pathSpecs) {
-      this.webAppFilterPathSpecs = pathSpecs == null
+    public Builder setWebAppFilterPathSpecs(String[] filterPathSpecs) {
+      this.webAppFilterPathSpecs = filterPathSpecs == null
           ? DEFAULT_WEB_APP_FILTER_PATH_SPECS.clone()
-          : pathSpecs.clone();
+          : filterPathSpecs.clone();
       return this;
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -186,6 +186,8 @@ public final class HttpServer2 implements FilterContainer {
   private static final String BIND_ADDRESS = "bind.address";
   private static final String HADOOP_JETTY_LOGS_SERVE_ALIASES = "hadoop.jetty.logs.serve.aliases";
   private static final boolean DEFAULT_HADOOP_JETTY_LOGS_SERVE_ALIASES = true;
+  private static final String[] DEFAULT_WEB_APP_FILTER_PATH_SPECS =
+      new String[] {"*.html", "*.jsp"};
 
   private final AccessControlList adminsAcl;
 
@@ -198,6 +200,7 @@ public final class HttpServer2 implements FilterContainer {
   private final WebAppContext webAppContext;
   private final boolean findPort;
   private final IntegerRanges portRanges;
+  private final String[] webAppFilterPathSpecs;
   private final Map<ServletContextHandler, Boolean> defaultContexts =
       new HashMap<>();
   private final List<String> filterNames = new ArrayList<>();
@@ -227,6 +230,8 @@ public final class HttpServer2 implements FilterContainer {
     private MutableConfigurationSource conf;
     private ConfigurationSource sslConf;
     private String[] pathSpecs;
+    private String[] webAppFilterPathSpecs =
+        DEFAULT_WEB_APP_FILTER_PATH_SPECS.clone();
     private AccessControlList adminsAcl;
     private boolean securityEnabled = false;
     private String usernameConfKey;
@@ -341,6 +346,13 @@ public final class HttpServer2 implements FilterContainer {
 
     public Builder setPathSpec(String[] pathSpec) {
       this.pathSpecs = pathSpec.clone();
+      return this;
+    }
+
+    public Builder setWebAppFilterPathSpecs(String[] pathSpecs) {
+      this.webAppFilterPathSpecs = pathSpecs == null
+          ? DEFAULT_WEB_APP_FILTER_PATH_SPECS.clone()
+          : pathSpecs.clone();
       return this;
     }
 
@@ -619,6 +631,7 @@ public final class HttpServer2 implements FilterContainer {
     this.webAppContext = createWebAppContext(b, adminsAcl, appDir);
     this.xFrameOptionIsEnabled = b.xFrameEnabled;
     this.xFrameOption = b.xFrameOption;
+    this.webAppFilterPathSpecs = b.webAppFilterPathSpecs.clone();
 
     try {
       this.secretProvider =
@@ -1044,12 +1057,15 @@ public final class HttpServer2 implements FilterContainer {
       Map<String, String> parameters) {
 
     FilterHolder filterHolder = createFilterHolder(name, classname, parameters);
-    FilterMapping fmap =
-        createFilterMapping(name, new String[] {"*.html", "*.jsp"});
-    defineFilter(webAppContext, filterHolder, fmap);
+    if (webAppFilterPathSpecs.length == 0) {
+      webAppContext.getServletHandler().addFilter(filterHolder);
+    } else {
+      FilterMapping fmap = createFilterMapping(name, webAppFilterPathSpecs);
+      defineFilter(webAppContext, filterHolder, fmap);
+    }
     LOG.info("Added filter {} (class={}) to context {}", name, classname,
             webAppContext.getDisplayName());
-    fmap = createFilterMapping(name, new String[] {"/*"});
+    FilterMapping fmap = createFilterMapping(name, new String[] {"/*"});
     for (Map.Entry<ServletContextHandler, Boolean> e
         : defaultContexts.entrySet()) {
       if (e.getValue()) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -18,8 +18,15 @@
 package org.apache.hadoop.hdds.server.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.jupiter.api.Test;
@@ -49,5 +56,71 @@ public class TestHttpServer2 {
       // Check default value in ozone-default.xml
       assertEquals(60000, server.getIdleTimeout());
     }
+  }
+
+  @Test
+  public void addFilterUsesDefaultWebAppPathSpecs() throws Exception {
+    HttpServer2 server = newServer(null);
+    try {
+      addTestFilter(server);
+
+      assertIterableEquals(Arrays.asList("*.html", "*.jsp"),
+          getPathSpecs(server, "testFilter"));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void addFilterUsesConfiguredWebAppPathSpecs() throws Exception {
+    HttpServer2 server = newServer(new String[] {"/custom/*"});
+    try {
+      addTestFilter(server);
+
+      assertIterableEquals(Collections.singletonList("/custom/*"),
+          getPathSpecs(server, "testFilter"));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void addFilterCanSkipWebAppPathSpecs() throws Exception {
+    HttpServer2 server = newServer(new String[0]);
+    try {
+      addTestFilter(server);
+
+      assertTrue(getPathSpecs(server, "testFilter").isEmpty());
+      assertIterableEquals(Collections.singletonList("/*"),
+          getPathSpecs(server, "safety"));
+    } finally {
+      server.stop();
+    }
+  }
+
+  private static HttpServer2 newServer(String[] pathSpecs) throws IOException {
+    HttpServer2.Builder builder = new HttpServer2.Builder()
+        .setConf(new OzoneConfiguration())
+        .setName("testing")
+        .addEndpoint(URI.create("http://localhost:0"));
+    if (pathSpecs != null) {
+      builder.setWebAppFilterPathSpecs(pathSpecs);
+    }
+    return builder.build();
+  }
+
+  private static void addTestFilter(HttpServer2 server) {
+    server.addFilter("testFilter",
+        HttpServer2.QuotingInputFilter.class.getName(), Collections.emptyMap());
+  }
+
+  private static List<String> getPathSpecs(HttpServer2 server,
+      String filterName) {
+    return Arrays.stream(server.getWebAppContext().getServletHandler()
+            .getFilterMappings())
+        .filter(mapping -> filterName.equals(mapping.getFilterName()))
+        .flatMap(mapping -> Arrays.stream(mapping.getPathSpecs() == null
+            ? new String[0] : mapping.getPathSpecs()))
+        .collect(Collectors.toList());
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
@@ -26,6 +26,9 @@ import org.apache.hadoop.hdds.server.http.BaseHttpServer;
  */
 public class S3GatewayHttpServer extends BaseHttpServer {
 
+  private static final String[] NO_WEB_APP_FILTER_PATH_SPECS =
+      new String[0];
+
   /**
    * Default offset between two filters.
    */
@@ -39,6 +42,11 @@ public class S3GatewayHttpServer extends BaseHttpServer {
   @Override
   protected boolean shouldAddDefaultApps() {
     return false;
+  }
+
+  @Override
+  protected String[] getWebAppFilterPathSpecs() {
+    return NO_WEB_APP_FILTER_PATH_SPECS;
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayHttpServerFilterMapping.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayHttpServerFilterMapping.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.server.http.HttpServer2;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.security.AuthenticationFilterInitializer;
+import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests S3 Gateway HTTP filter path mappings.
+ */
+class TestS3GatewayHttpServerFilterMapping {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void s3ApiDoesNotMapAuthenticationFilterToHtmlObjects()
+      throws Exception {
+    InspectableS3GatewayHttpServer server =
+        new InspectableS3GatewayHttpServer(newConfig());
+    try {
+      WebAppContext context = server.webAppContext();
+
+      assertTrue(hasAuthenticationFilter(context));
+      assertFalse(getPathSpecs(context).contains("*.html"));
+      assertFalse(getPathSpecs(context).contains("*.jsp"));
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  void s3WebAdminKeepsAuthenticationFilterForHtmlPages()
+      throws Exception {
+    InspectableS3GatewayWebAdminServer server =
+        new InspectableS3GatewayWebAdminServer(newConfig());
+    try {
+      WebAppContext context = server.webAppContext();
+
+      assertTrue(hasAuthenticationFilter(context));
+      assertTrue(getPathSpecs(context).contains("*.html"));
+      assertTrue(getPathSpecs(context).contains("*.jsp"));
+    } finally {
+      server.stop();
+    }
+  }
+
+  private OzoneConfiguration newConfig() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR, tempDir.toString());
+    conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY,
+        HttpConfig.Policy.HTTP_ONLY.name());
+    conf.set(HttpServer2.FILTER_INITIALIZER_PROPERTY,
+        AuthenticationFilterInitializer.class.getName());
+    conf.set("hadoop.http.authentication.type", "simple");
+    conf.set("hadoop.http.authentication.simple.anonymous.allowed", "true");
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY, "localhost:0");
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY, "localhost");
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY,
+        "localhost:0");
+    conf.set(S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY,
+        "localhost");
+    return conf;
+  }
+
+  private static boolean hasAuthenticationFilter(WebAppContext context) {
+    return Arrays.stream(context.getServletHandler().getFilters())
+        .anyMatch(filter -> AuthenticationFilter.class.getName()
+            .equals(filter.getClassName()));
+  }
+
+  private static List<String> getPathSpecs(WebAppContext context) {
+    return Arrays.stream(context.getServletHandler().getFilterMappings())
+        .flatMap(mapping -> Arrays.stream(mapping.getPathSpecs() == null
+            ? new String[0] : mapping.getPathSpecs()))
+        .collect(Collectors.toList());
+  }
+
+  private static class InspectableS3GatewayHttpServer
+      extends S3GatewayHttpServer {
+
+    InspectableS3GatewayHttpServer(OzoneConfiguration conf)
+        throws IOException {
+      super(conf, "s3gateway");
+    }
+
+    WebAppContext webAppContext() {
+      return getWebAppContext();
+    }
+  }
+
+  private static class InspectableS3GatewayWebAdminServer
+      extends S3GatewayWebAdminServer {
+
+    InspectableS3GatewayWebAdminServer(OzoneConfiguration conf)
+        throws IOException {
+      super(conf, "s3g-web");
+    }
+
+    WebAppContext webAppContext() {
+      return getWebAppContext();
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes S3G uploads for object keys ending with `.html`/`.jsp` when WebUI authentication is enabled.

`HttpServer2` maps `AuthenticationFilterInitializer` filters to `*.html` and `*.jsp` on the main webapp by default. Since S3G serves S3 object API requests from the same main webapp, object paths like `/bucket/page.html` were intercepted by the WebUI/SPNEGO filter before S3 SigV4 handling and failed with `401 Unauthorized`.

The fix adds an internal `HttpServer2`/`BaseHttpServer` hook to override main webapp filter path specs, and disables those WebUI filter mappings only for the S3 API server. S3G WebAdmin keeps the existing WebUI auth behavior.

## Changes

- Added `HttpServer2.Builder#setWebAppFilterPathSpecs`.
- Added `BaseHttpServer#getWebAppFilterPathSpecs`.
- Disabled WebUI initializer filter path mappings for `S3GatewayHttpServer`.
- Kept S3G WebAdmin HTML/JSP filter mappings unchanged.
- Added regression tests for default/custom/empty filter mappings and S3G API vs WebAdmin behavior.
- Updated S3G HTTP security documentation.